### PR TITLE
Fix hero animation overflow bug

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ const Index = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       }
     >
       <Nav />
-      <Container maxW="container.lg">
+      <Container overflow="hidden" maxW="container.lg">
         <Hero />
         <Box
           w={['xs', 'md', null, 'xl']}


### PR DESCRIPTION
Fixes #3 where on mobile your picture in the `<Hero>` component goes past the overflow-x boundaries.